### PR TITLE
Decouple results of tax calculation from their text representation

### DIFF
--- a/src/main/scala/uk/gov/hmrc/payeestimator/services/GovernmentSpendingReceiptingService.scala
+++ b/src/main/scala/uk/gov/hmrc/payeestimator/services/GovernmentSpendingReceiptingService.scala
@@ -8,25 +8,21 @@ import scala.scalajs.js.annotation.JSExport
 trait GovernmentSpendingReceiptingService {
 
   @JSExport
-  def getGovernmentReceiptingData(): String = {
-    val receiptingData = GovernmentReceiptData
-    val receiptingDataResponse = GovernmentReceiptDataResponse(receiptingData.year, receiptingData.governmentReceipting, receiptingData.totalGovernmentReceipts)
-    val result = buildReceiptingResponse(receiptingDataResponse)
-    result
+  def getGovernmentReceiptingData(): String = write(buildGovernmentReceiptingData)
+
+  def buildGovernmentReceiptingData: GovernmentReceiptDataResponse = {
+    import GovernmentReceiptData._
+    GovernmentReceiptDataResponse(year, governmentReceipting, totalGovernmentReceipts)
   }
 
   @JSExport
-  def getGovernmentSpendingData(): String = {
-    val spendingData = GovernmentSpendingData
-    val spendingDataResponse = GovernmentSpendingDataResponse(spendingData.year, spendingData.totalGovernmentReceipts, spendingData.governmentSpending)
-    buildSpendingResponse(spendingDataResponse)
+  def getGovernmentSpendingData(): String = write(buildGovernmentSpendingData)
+
+  def buildGovernmentSpendingData: GovernmentSpendingDataResponse = {
+    import GovernmentSpendingData._
+    GovernmentSpendingDataResponse(year, totalGovernmentReceipts, governmentSpending)
   }
 
-  @JSExport
-  def buildReceiptingResponse(governmentReceiptData:GovernmentReceiptDataResponse) = write(governmentReceiptData)
-
-  @JSExport
-  def buildSpendingResponse(governmentSpendingData:GovernmentSpendingDataResponse) = write(governmentSpendingData)
 }
 
 @JSExport

--- a/src/main/scala/uk/gov/hmrc/payeestimator/services/TaxCalculatorService.scala
+++ b/src/main/scala/uk/gov/hmrc/payeestimator/services/TaxCalculatorService.scala
@@ -40,7 +40,12 @@ trait TaxCalculatorService extends TaxCalculatorHelper {
 
   @JSExport
   def calculateTax(isStatePensionAge: String, taxYear: Int, taxCode: String, grossPayPence: Int, payPeriod: String, hoursIn: Int): String = {
+    val taxCalResult = buildTaxCalc(isStatePensionAge, taxYear, taxCode, grossPayPence, payPeriod, hoursIn)
+    write(taxCalResult)
+  }
 
+  def buildTaxCalc(isStatePensionAge: String, taxYear: Int, taxCode: String,
+                   grossPayPence: Int, payPeriod: String, hoursIn: Int): TaxCalc = {
     val hours = if (hoursIn > 0) Some(hoursIn) else None
     val isPensionAge = convertToBoolean(isStatePensionAge)
     val updatedPayPeriod = if (hours.getOrElse(-1) > 0) "annual" else payPeriod
@@ -69,9 +74,8 @@ trait TaxCalculatorService extends TaxCalculatorHelper {
 
     val averageAnnualTaxRate = calculateAverageAnnualTaxRate(taxBreakdown.find(_.period == "annual"))
 
-    val taxCalResult = TaxCalc(isPensionAge, taxCode, getHourlyGrossPay(hours, grossPayPence), hoursIn, averageAnnualTaxRate.value, payeTax.bandRate + nicTax.employeeNICBandRate, getTaxBands(LocalDate.now()).maxRate,payeTax.bandRate, nicTax.employeeNICBandRate, payeTax.isTapered, taxBreakdown)
+    TaxCalc(isPensionAge, taxCode, getHourlyGrossPay(hours, grossPayPence), hoursIn, averageAnnualTaxRate.value, payeTax.bandRate + nicTax.employeeNICBandRate, getTaxBands(LocalDate.now()).maxRate,payeTax.bandRate, nicTax.employeeNICBandRate, payeTax.isTapered, taxBreakdown)
 
-    buildResponse(taxCalResult)
   }
 
   def annualiseGrossPay(grossPayPence: Long, hours: Option[Int], payPeriod: String) = {
@@ -90,9 +94,6 @@ trait TaxCalculatorService extends TaxCalculatorHelper {
       case false => grossPay
     }
   }
-
-  @JSExport
-  def buildResponse(taxCalc:TaxCalc) = write(taxCalc)
 
   def convertToBoolean(isStatePensionAge: String): Boolean = {
     isStatePensionAge.toLowerCase() match {


### PR DESCRIPTION
At the moment methods exposed in JS return Strings with JSON. This is good for JS but
if you want to call the method from scala it would more convenient to have a strongly
typed object back instead. Also calling from scala doesn't work at all and following
exception is thrown:

```
Exception in thread "main" java.lang.ClassCastException:
scala.scalajs.js.Object cannot be cast to scala.scalajs.js.Dictionary
```

example code that would throw it:

```
object Foo extends App {
  println(
    LiveTaxCalculatorService.calculateTax("false", 2016, "1100T", 1000008, "annual", -1)
  )
}
```

This PR does not change the exposed API, but it adds intermediate methods that can be used directly from Scala.