### PR TITLE
fix: Update plugins version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,13 +5,11 @@ import uk.gov.hmrc.SbtArtifactory
 
 enablePlugins(SbtGitVersioning, ScalaJSPlugin, UniversalPlugin, SbtArtifactory)
 
-makePublicallyAvailableOnBintray := true
-
 name := "paye-estimator"
 
 LocalTempBuildSettings.localDefaultSettings
 
-majorVersion := 2
+majorVersion := 0
 
 scalaVersion := "2.11.12"
 
@@ -24,8 +22,6 @@ libraryDependencies ++= Seq(
 
 playCrossCompilationSettings
 
-makePublicallyAvailableOnBintray := true
-
 scalaJSStage in Global := FullOptStage
 
 topLevelDirectory := None
@@ -37,14 +33,14 @@ mappings in Universal ++= Seq((target.value / "scala-2.11" / s"${name.value}-opt
 val packageTgz = taskKey[File]("package-tgz")
 packageTgz := target.value / "universal" / (name.value + "-" + version.value + ".tgz")
 
-artifact in(Universal, packageTgz) ~= { art: Artifact => art.copy(`type` = "tgz", extension = "tgz") }
-addArtifact(artifact in(Universal, packageTgz), packageTgz in Universal)
+// artifact in(Universal, packageTgz) ~= { art: Artifact => art.copy(`type` = "tgz", extension = "tgz") }
+// addArtifact(artifact in(Universal, packageTgz), packageTgz in Universal)
 
 
-publishAndDistribute := (publishAndDistribute dependsOn (fullOptJS in Compile)).value
+// publishAndDistribute := (publishAndDistribute dependsOn (fullOptJS in Compile)).value
 
-publish <<= publish dependsOn (packageZipTarball in Universal)
+// publish <<= publish dependsOn (packageZipTarball in Universal)
 
-publishM2 <<= publishM2 dependsOn (packageZipTarball in Universal)
+// publishM2 <<= publishM2 dependsOn (packageZipTarball in Universal)
 
-publishLocal <<= publishLocal dependsOn (packageZipTarball in Universal)
+// publishLocal <<= publishLocal dependsOn (packageZipTarball in Universal)

--- a/build.sbt
+++ b/build.sbt
@@ -9,9 +9,11 @@ name := "paye-estimator"
 
 LocalTempBuildSettings.localDefaultSettings
 
+// TODO: I get complains when the major version is anything but 0, 
+// again, not sure why.
 majorVersion := 0
 
-scalaVersion := "2.11.12"
+scalaVersion := "2.12.17"
 
 crossScalaVersions := Seq("2.11.12")
 
@@ -33,14 +35,14 @@ mappings in Universal ++= Seq((target.value / "scala-2.11" / s"${name.value}-opt
 val packageTgz = taskKey[File]("package-tgz")
 packageTgz := target.value / "universal" / (name.value + "-" + version.value + ".tgz")
 
-// artifact in(Universal, packageTgz) ~= { art: Artifact => art.copy(`type` = "tgz", extension = "tgz") }
-// addArtifact(artifact in(Universal, packageTgz), packageTgz in Universal)
+artifact in(Universal, packageTgz) ~= { art: Artifact => art.withType("tgz").withExtension("tgz") }
+addArtifact(artifact in(Universal, packageTgz), packageTgz in Universal)
 
-
+// TODO: this doesn't work and I'm not sure why.
 // publishAndDistribute := (publishAndDistribute dependsOn (fullOptJS in Compile)).value
 
-// publish <<= publish dependsOn (packageZipTarball in Universal)
+publish := publish dependsOn (packageZipTarball in Universal)
 
-// publishM2 <<= publishM2 dependsOn (packageZipTarball in Universal)
+publishM2 := publishM2 dependsOn (packageZipTarball in Universal)
 
-// publishLocal <<= publishLocal dependsOn (packageZipTarball in Universal)
+publishLocal := publishLocal dependsOn (packageZipTarball in Universal)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,9 +12,6 @@ object Dependencies {
         "org.scalatest" %% "scalatest" % "3.0.5" % "test",
         "org.pegdown" % "pegdown" % "1.6.0"
       ),
-      play25 = Seq(
-        "com.typesafe.play" %% "play-json" % play25Version % "test"
-      ),
       play26 = Seq(
         "com.typesafe.play" %% "play-json" % play26Version % "test"
       )

--- a/project/LocalTempBuildSettings.scala
+++ b/project/LocalTempBuildSettings.scala
@@ -18,34 +18,6 @@ import org.eclipse.jgit.lib.{BranchConfig, Repository}
 import sbt.Keys._
 import sbt._
 
-trait License {
-  def apply(yyyy: String, copyrightOwner: String, commentStyle: String = "*"): (Regex, String) = {
-    val text = createLicenseText(yyyy, copyrightOwner)
-    (new Regex(""), "")
-  }
-
-  def createLicenseText(yyyy: String, copyrightOwner: String): String
-}
-
-object Apache2_0 extends License {
-  override def createLicenseText(yyyy: String, copyrightOwner: String) = {
-    s"""|Copyright $yyyy $copyrightOwner
-        |
-        |Licensed under the Apache License, Version 2.0 (the "License");
-        |you may not use this file except in compliance with the License.
-        |You may obtain a copy of the License at
-        |
-        |    http://www.apache.org/licenses/LICENSE-2.0
-        |
-        |Unless required by applicable law or agreed to in writing, software
-        |distributed under the License is distributed on an "AS IS" BASIS,
-        |WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-        |See the License for the specific language governing permissions and
-        |limitations under the License.
-        |""".stripMargin
-  }
-}
-
 object LocalTempBuildSettings extends AutoPlugin {
 
   import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport._

--- a/project/LocalTempBuildSettings.scala
+++ b/project/LocalTempBuildSettings.scala
@@ -13,10 +13,38 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+import scala.util.matching.Regex
 import org.eclipse.jgit.lib.{BranchConfig, Repository}
 import sbt.Keys._
 import sbt._
+
+trait License {
+  def apply(yyyy: String, copyrightOwner: String, commentStyle: String = "*"): (Regex, String) = {
+    val text = createLicenseText(yyyy, copyrightOwner)
+    (new Regex(""), "")
+  }
+
+  def createLicenseText(yyyy: String, copyrightOwner: String): String
+}
+
+object Apache2_0 extends License {
+  override def createLicenseText(yyyy: String, copyrightOwner: String) = {
+    s"""|Copyright $yyyy $copyrightOwner
+        |
+        |Licensed under the Apache License, Version 2.0 (the "License");
+        |you may not use this file except in compliance with the License.
+        |You may obtain a copy of the License at
+        |
+        |    http://www.apache.org/licenses/LICENSE-2.0
+        |
+        |Unless required by applicable law or agreed to in writing, software
+        |distributed under the License is distributed on an "AS IS" BASIS,
+        |WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        |See the License for the specific language governing permissions and
+        |limitations under the License.
+        |""".stripMargin
+  }
+}
 
 object LocalTempBuildSettings extends AutoPlugin {
 
@@ -32,8 +60,8 @@ object LocalTempBuildSettings extends AutoPlugin {
       Resolvers() ++
       ArtefactDescription() ++
       Seq(
-        targetJvm := "jvm-1.8",
-        headers := HeaderSettings()
+        targetJvm := "jvm-1.8"
+        // headers := HeaderSettings()
       )
 }
 
@@ -62,13 +90,13 @@ object PublishSettings {
 }
 
 object HeaderSettings {
-
-  import de.heikoseeberger.sbtheader.license.Apache2_0
   import org.joda.time.DateTime
 
   val copyrightYear = DateTime.now().getYear.toString
   val copyrightOwner = "HM Revenue & Customs"
 
+  // The support for this type of mapping has been dropped
+  // headerLicense := Some(HeaderLicense.MIT("2015", "Heiko Seeberger"))
   def apply() = {
     Map(
       "scala" -> Apache2_0(copyrightYear, copyrightOwner),

--- a/project/PlayCrossCompilation.scala
+++ b/project/PlayCrossCompilation.scala
@@ -1,4 +1,8 @@
-import uk.gov.hmrc.playcrosscompilation.AbstractPlayCrossCompilation
-import uk.gov.hmrc.playcrosscompilation.PlayVersion._
+// import uk.gov.hmrc.playcrosscompilation.AbstractPlayCrossCompilation
+// import uk.gov.hmrc.playcrosscompilation.PlayVersion._
 
-object PlayCrossCompilation extends AbstractPlayCrossCompilation(defaultPlayVersion = Play25)
+// object PlayCrossCompilation extends AbstractPlayCrossCompilation(defaultPlayVersion = Play25)
+
+import uk.gov.hmrc.playcrosscompilation.{AbstractPlayCrossCompilation, PlayVersion}
+
+object PlayCrossCompilation extends AbstractPlayCrossCompilation(defaultPlayVersion = PlayVersion.Play26)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.17
+sbt.version=1.7.2

--- a/project/metals.sbt
+++ b/project/metals.sbt
@@ -1,0 +1,6 @@
+// DO NOT EDIT! This file is auto-generated.
+
+// This file enables sbt-bloop to create bloop config files.
+
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.5.6")
+

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,13 +1,11 @@
+resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefacts.tax.service.gov.uk/maven2")
+resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
-resolvers ++= Seq(Resolver.url("hmrc-sbt-plugin-releases", url("https://dl.bintray.com/hmrc/sbt-plugin-releases"))(Resolver.ivyStylePatterns),
-  "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/",
-  "HMRC Releases" at "https://dl.bintray.com/hmrc/releases")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.6.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "1.13.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.4.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "1.15.0")
-
-addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "0.18.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "2.0.0")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.26")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,13 @@
 resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefacts.tax.service.gov.uk/maven2")
 resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.6.0")
+// newest version
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.9.0")
 
+// newest version
 addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.4.0")
 
+// newest version
 addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "2.0.0")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.26")
@@ -13,4 +16,4 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.15")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-play-cross-compilation" % "0.12.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-play-cross-compilation" % "2.3.0")

--- a/src/main/scala/uk/gov/hmrc/payeestimator/domain/CalculatorSeedData.scala
+++ b/src/main/scala/uk/gov/hmrc/payeestimator/domain/CalculatorSeedData.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/payeestimator/domain/CategoryBreakdown.scala
+++ b/src/main/scala/uk/gov/hmrc/payeestimator/domain/CategoryBreakdown.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/payeestimator/domain/Money.scala
+++ b/src/main/scala/uk/gov/hmrc/payeestimator/domain/Money.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/payeestimator/domain/TaxCalc.scala
+++ b/src/main/scala/uk/gov/hmrc/payeestimator/domain/TaxCalc.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/payeestimator/domain/TaxCalcSetup.scala
+++ b/src/main/scala/uk/gov/hmrc/payeestimator/domain/TaxCalcSetup.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/payeestimator/services/Builder.scala
+++ b/src/main/scala/uk/gov/hmrc/payeestimator/services/Builder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/payeestimator/services/Calculator.scala
+++ b/src/main/scala/uk/gov/hmrc/payeestimator/services/Calculator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/payeestimator/services/CalculatorResponse.scala
+++ b/src/main/scala/uk/gov/hmrc/payeestimator/services/CalculatorResponse.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/payeestimator/services/NICTaxCalculatorService.scala
+++ b/src/main/scala/uk/gov/hmrc/payeestimator/services/NICTaxCalculatorService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/payeestimator/services/PAYETaxCalculatorService.scala
+++ b/src/main/scala/uk/gov/hmrc/payeestimator/services/PAYETaxCalculatorService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/payeestimator/services/TaxCalculatorHelper.scala
+++ b/src/main/scala/uk/gov/hmrc/payeestimator/services/TaxCalculatorHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package uk.gov.hmrc.payeestimator.services
 
 import uk.gov.hmrc.payeestimator.domain._

--- a/src/main/scala/uk/gov/hmrc/payeestimator/services/TaxCalculatorService.scala
+++ b/src/main/scala/uk/gov/hmrc/payeestimator/services/TaxCalculatorService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Not perfect, but at least now this compiles. 

List of changes: 
- Scala version updated in build.sbt
- Artifact setting updated to new syntax
- Play version udpdated (play25 doesn't seem to be an option anymore)
- Commented out the licence headers since that library no longer supports doing them this way
- Updated all the uk.gov.hmrc plugins